### PR TITLE
Selective gzip instead of compressing everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@ calculating the MD5 sum of the content on the client side).
 `--content-type=CONTENT-TYPE` sets the `Content-Type` header. 
 (accepted parameter `guess`), (eg. `--content-type=guess`)
 
-`--gzip` compresses all values and sets the `Content-Encoding` header to
+`--gzip` compresses common text files and sets the `Content-Encoding` header to
 `gzip`.
+
+`--gzip-type=CONTENT-TYPE` can be used multiple times to specify what content
+types should be gzipped.  To extend the existing set, specify `guess` too, (eg.
+`--gzip-type=guess --gzip-type="image/svg+xml").  To gzip everything, specify
+`all`, (eg. `--gzip-type=all`).
 
 `--processes=N` sets the number of parallel upload processes.
 

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -248,8 +248,9 @@ def putter(put, put_queue, stat_queue, options):
 
                 content = value.get_content()
                 md5 = value.md5
-                should_gzip = options.gzip and (content_type in gzip_content_types
-                    or gzip_content_types == GZIP_ALL)
+                should_gzip = options.gzip and (
+                    content_type and content_type in gzip_content_types or
+                    gzip_content_types == GZIP_ALL)
                 if should_gzip:
                     headers['Content-Encoding'] = 'gzip'
                     string_io = StringIO()

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -47,6 +47,15 @@ from boto.utils import compute_md5
 
 DONE_RE = re.compile(r'\AINFO:s3-parallel-put\[putter-\d+\]:\S+\s+->\s+(\S+)\s*\Z')
 
+# These content types are amenable to compression
+GZIP_CONTENT_TYPES = (
+    'application/javascript',
+    'application/x-javascript',
+    'text/css',
+    'text/html',
+    'text/javascript',
+)
+
 
 def repeatedly(func, *args, **kwargs):
     while True:
@@ -225,7 +234,7 @@ def putter(put, put_queue, stat_queue, options):
 
                 content = value.get_content()
                 md5 = value.md5
-                if options.gzip:
+                if options.gzip and content_type in GZIP_CONTENT_TYPES:
                     headers['Content-Encoding'] = 'gzip'
                     string_io = StringIO()
                     gzip_file = GzipFile(compresslevel=9, fileobj=string_io, mode='w')

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -248,8 +248,9 @@ def putter(put, put_queue, stat_queue, options):
 
                 content = value.get_content()
                 md5 = value.md5
-                if options.gzip and (content_type in gzip_content_types
-                        or gzip_content_types == GZIP_ALL):
+                should_gzip = options.gzip and (content_type in gzip_content_types
+                    or gzip_content_types == GZIP_ALL)
+                if should_gzip:
                     headers['Content-Encoding'] = 'gzip'
                     string_io = StringIO()
                     gzip_file = GzipFile(compresslevel=9, fileobj=string_io, mode='w')
@@ -259,7 +260,8 @@ def putter(put, put_queue, stat_queue, options):
                     md5 = compute_md5(StringIO(content))
                 if not options.dry_run:
                     key.set_contents_from_string(content, headers, md5=md5, policy=options.grant)
-                logger.info('%s -> %s' % (value.path, key.name))
+                logger.info('%s %s> %s' % (
+                    value.path, 'z' if should_gzip else '-', key.name))
                 stat_queue.put(dict(size=value.get_size()))
             else:
                 logger.info('skipping %s -> %s' % (value.path, key_name))

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -214,11 +214,14 @@ def putter(put, put_queue, stat_queue, options):
                     headers = dict(tuple(header.split(':', 1)) for header in options.headers)
                 else:
                     headers = {}
+
+                content_type = None
                 if options.content_type:
                     if options.content_type == "guess":
-                        headers['Content-Type'] = mimetypes.guess_type(value.path)[0]
+                        content_type = mimetypes.guess_type(value.path)[0]
                     else:
-                        headers['Content-Type'] = options.content_type
+                        content_type = options.content_type
+                    headers['Content-Type'] = content_type
 
                 content = value.get_content()
                 md5 = value.md5

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -48,6 +48,7 @@ from boto.utils import compute_md5
 DONE_RE = re.compile(r'\AINFO:s3-parallel-put\[putter-\d+\]:\S+\s+->\s+(\S+)\s*\Z')
 
 # These content types are amenable to compression
+# WISHLIST more types means more internets
 GZIP_CONTENT_TYPES = (
     'application/javascript',
     'application/x-javascript',
@@ -55,6 +56,7 @@ GZIP_CONTENT_TYPES = (
     'text/html',
     'text/javascript',
 )
+GZIP_ALL = 'all'
 
 
 def repeatedly(func, *args, **kwargs):
@@ -205,6 +207,18 @@ def putter(put, put_queue, stat_queue, options):
     logger = logging.getLogger('%s[putter-%d]' % (os.path.basename(sys.argv[0]), current_process().pid))
     connection, bucket = None, None
     file_object_cache = FileObjectCache()
+    # Figure out what content types we want to gzip
+    if not options.gzip_type:  # default
+        gzip_content_types = GZIP_CONTENT_TYPES
+    elif 'all' in options.gzip_type:
+        gzip_content_types = GZIP_ALL
+    else:
+        gzip_content_types = options.gzip_type
+    if 'guess' in gzip_content_types:
+        # don't bother removing 'guess' from the list since nothing will match it
+        gzip_content_types.extend(GZIP_CONTENT_TYPES)
+    if options.gzip:
+        logger.debug('These content types will be gzipped: %s' % unicode(gzip_content_types))
     while True:
         args = put_queue.get()
         if args is None:
@@ -234,7 +248,8 @@ def putter(put, put_queue, stat_queue, options):
 
                 content = value.get_content()
                 md5 = value.md5
-                if options.gzip and content_type in GZIP_CONTENT_TYPES:
+                if options.gzip and (content_type in gzip_content_types
+                        or gzip_content_types == GZIP_ALL):
                     headers['Content-Encoding'] = 'gzip'
                     string_io = StringIO()
                     gzip_file = GzipFile(compresslevel=9, fileobj=string_io, mode='w')
@@ -291,6 +306,11 @@ def main(argv):
             help='set content type, set to "guess" to guess based on file name')
     group.add_option('--gzip', action='store_true',
             help='gzip values and set content encoding')
+    group.add_option('--gzip-type', action='append', default=[],
+            help='if --gzip is set, sets what content-type to gzip, defaults '
+            'to a list of known text content types, "all" will gzip everything.'
+            ' Specify multiple times for multiple content types. '
+            '[default: "guess"]')
     group.add_option('--put', choices=('add', 'stupid', 'update'), default='update', metavar='MODE',
             help='set put mode (add, stupid, or update)')
     group.add_option('--prefix', default='', metavar='PREFIX',


### PR DESCRIPTION
Currently, if you enable the `--gzip` flag, this will gzip **everything**. But generally, you only want to gzip text content.

This change follows the same patterns I've found in django-extensions https://github.com/django-extensions/django-extensions/blob/master/django_extensions/management/commands/sync_s3.py#L351-L354 and django-storages https://github.com/django-extensions/django-extensions/blob/master/django_extensions/management/commands/sync_s3.py#L351-L354

## Changes
* `--gzip` now only gzips some content-types **backwards incompatible**. To get the old behavior, use `--gzip --gzip-type=all`
* Adds `--gzip-type=CONTENT_TYPE` option, to give user control over what should be gzipped. Omitting this is the same as saying `--gzip-type=guess`, using "guess" to be consistent with the content-type option.
* Changes the logging output to indicate if a file was uploaded gzipped or not. Instead of an arrow, `->`, there's a zippy arrow: `z>` For example:

        INFO:s3-parallel-put[putter-93024]:test/.DS_Store z> test/.DS_Store

## How to manually test this

Build a directory with a bunch of files in it:
```bash
mkdir test && cd test
wget http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js
wget ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css
wget http://apod.nasa.gov/apod/image/0504/WaterOnMars2_gcc.jpg
echo ",,," > something.csv
cd ..
```

Things to test. Look for `z>` instead of `->` to know if it was transferred gzipped or not. You have to run this against a real bucket name, you can do `export AWS_BUCKET=my-little-bucket` to copy paste the examples below.

#### nothing will be gzipped:
```bash
./s3-parallel-put --bucket=$AWS_BUCKET --dry-run --content-type=guess \
  --gzip test/
```

#### only css and js will be gzipped
```bash
./s3-parallel-put --bucket=$AWS_BUCKET --dry-run --content-type=guess \
  --gzip test/
```

#### everything will be gzipped
```bash
./s3-parallel-put --bucket=$AWS_BUCKET --dry-run --content-type=guess \
  --gzip --gzip-type=all test/
```

#### only the jpg image will be gzipped
```bash
./s3-parallel-put --bucket=$AWS_BUCKET --dry-run --content-type=guess \
  --gzip --gzip-type=image/jpeg test/
```

#### the css, js, and image will be gzipped
```bash
./s3-parallel-put --bucket=$AWS_BUCKET --dry-run --content-type=guess \
  --gzip --gzip-type=image/jpeg --gzip-type=guess test/
```

#### TODO
* [x] have a way to gzip everything like before this PR was opened
* [x] have a way to control which content types get gzipped
* [x] documentation