### PR TITLE
Protect against IOErrors so the process doesn't exit

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -270,6 +270,8 @@ def putter(put, put_queue, stat_queue, options):
             logger.error('%s -> %s (%s)' % (value.path, key_name, exc))
             put_queue.put(args)
             connection, bucket = None, None
+        except IOError as exc:
+            logger.error('%s -> %s (%s)' % (value.path, key_name, exc))
         put_queue.task_done()
 
 


### PR DESCRIPTION
I found myself in a situation where I was getting IO errors every now and then, and it was causing processes to die that weren't getting recreated.  This protects against that.