### PR TITLE
Add option to enable server side encryption

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -282,7 +282,7 @@ def putter(put, put_queue, stat_queue, options):
                         content = string_io.getvalue()
                         md5 = compute_md5(StringIO(content))
                     if not options.dry_run:
-                        key.set_contents_from_string(content, headers, md5=md5, policy=options.grant)
+                        key.set_contents_from_string(content, headers, md5=md5, policy=options.grant, encrypt_key=options.encrypt_key)
                 logger.info('%s %s> %s' % (
                     value.path, 'z' if should_gzip else '-', key.name))
                 stat_queue.put(dict(size=value.get_size()))
@@ -349,6 +349,8 @@ def main(argv):
             ', '.join(CannedACLStrings))
     group.add_option('--header', metavar='HEADER:VALUE', dest='headers', action='append',
                      help='extra headers to add to the file, can be specified multiple times')
+    group.add_option('--encrypt-key', action='store_true', default=False, dest='encrypt_key',
+            help='use server side encryption')
     parser.add_option_group(group)
     group = OptionGroup(parser, 'Logging options')
     group.add_option('--log-filename', metavar='FILENAME',


### PR DESCRIPTION
This adds the option ``--encrypt-key`` which when specified will turn on server side encryption.  It is disabled by default.   

This will allow the user to upload content which is stored in an encrypted form while at rest in S3.