### PR TITLE
Support buckets in other regions. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 s3-parallel-put  Parallel uploads to Amazon AWS S3
 ==================================================
 
+THIS IS A FORK FOR https://github.com/twpayne/s3-parallel-put/pull/23 PR #23 to support regionalized buckets.
 s3-parallel-put speeds the uploading of many small keys to Amazon AWS S3 by
 executing multiple PUTs in parallel.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 s3-parallel-put  Parallel uploads to Amazon AWS S3
 ==================================================
 
-THIS IS A FORK FOR https://github.com/twpayne/s3-parallel-put/pull/23 PR #23 to support regionalized buckets.
 s3-parallel-put speeds the uploading of many small keys to Amazon AWS S3 by
 executing multiple PUTs in parallel.
 

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -40,6 +40,7 @@ import tarfile
 import time
 import mimetypes
 
+from boto.s3.connection.Location import Location
 from boto.s3.connection import S3Connection
 from boto.s3.acl import CannedACLStrings
 from boto.utils import compute_md5
@@ -377,13 +378,13 @@ def main(argv):
     if not options.bucket:
         logger.error('missing bucket')
         return 1
-    #connection = S3Connection(is_secure=options.secure)
-    connection = boto.s3.connect_to_region(options.region,
-       aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
-       aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
-       is_secure=options.secure,
-       calling_format = boto.s3.connection.OrdinaryCallingFormat(),
-       )
+    connection = S3Connection(is_secure=options.secure, Location=USWest2)
+    # connection = boto.s3.connect_to_region(options.region,
+    #   aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+    #   aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+    #   is_secure=options.secure,
+    #   calling_format = boto.s3.connection.OrdinaryCallingFormat(),
+    #   )
     bucket = connection.get_bucket(options.bucket)
     del bucket
     del connection

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -40,7 +40,7 @@ import tarfile
 import time
 import mimetypes
 
-from boto.s3.connection import Location
+import boto
 from boto.s3.connection import S3Connection
 from boto.s3.acl import CannedACLStrings
 from boto.utils import compute_md5
@@ -378,7 +378,13 @@ def main(argv):
     if not options.bucket:
         logger.error('missing bucket')
         return 1
-    connection = S3Connection(is_secure=options.secure, Location=Location.USWest2)
+    #connection = S3Connection(is_secure=options.secure, Location=Location.USWest2)
+    connection = boto.s3.connect_to_region('us-west-2',
+       aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+       aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+       is_secure=True,
+       calling_format = boto.s3.connection.OrdinaryCallingFormat(),
+       )
     bucket = connection.get_bucket(options.bucket)
     del bucket
     del connection

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -377,7 +377,13 @@ def main(argv):
     if not options.bucket:
         logger.error('missing bucket')
         return 1
-    connection = S3Connection(is_secure=options.secure)
+    #connection = S3Connection(is_secure=options.secure)
+    connection = boto.s3.connect_to_region(options.region,
+       aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+       aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+       is_secure=options.secure,
+       calling_format = boto.s3.connection.OrdinaryCallingFormat(),
+       )
     bucket = connection.get_bucket(options.bucket)
     del bucket
     del connection

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -378,8 +378,7 @@ def main(argv):
     if not options.bucket:
         logger.error('missing bucket')
         return 1
-    #connection = S3Connection(is_secure=options.secure, Location=Location.USWest2)
-    connection = boto.s3.connect_to_region('us-west-2',
+    connection = boto.s3.connect_to_region(options.bucket_region,
        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
        is_secure=True,

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -40,7 +40,7 @@ import tarfile
 import time
 import mimetypes
 
-from boto.s3.connection.Location import Location
+from boto.s3.connection import Location
 from boto.s3.connection import S3Connection
 from boto.s3.acl import CannedACLStrings
 from boto.utils import compute_md5

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -378,13 +378,7 @@ def main(argv):
     if not options.bucket:
         logger.error('missing bucket')
         return 1
-    connection = S3Connection(is_secure=options.secure, Location=USWest2)
-    # connection = boto.s3.connect_to_region(options.region,
-    #   aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
-    #   aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
-    #   is_secure=options.secure,
-    #   calling_format = boto.s3.connection.OrdinaryCallingFormat(),
-    #   )
+    connection = S3Connection(is_secure=options.secure, Location=Location.USWest2)
     bucket = connection.get_bucket(options.bucket)
     del bucket
     del connection


### PR DESCRIPTION
Fixes issue https://github.com/twpayne/s3-parallel-put/issues/21 when buckets are not in the US Standard region. Allows command line option to specify a string region such as `--bucket-region=us-west-2`. 