### PR TITLE
Support buckets in other regions.

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -40,6 +40,7 @@ import tarfile
 import time
 import mimetypes
 
+import boto
 from boto.s3.connection import S3Connection
 from boto.s3.acl import CannedACLStrings
 from boto.utils import compute_md5
@@ -377,7 +378,12 @@ def main(argv):
     if not options.bucket:
         logger.error('missing bucket')
         return 1
-    connection = S3Connection(is_secure=options.secure)
+    connection = boto.s3.connect_to_region(options.bucket_region,
+       aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+       aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+       is_secure=True,
+       calling_format = boto.s3.connection.OrdinaryCallingFormat(),
+       )
     bucket = connection.get_bucket(options.bucket)
     del bucket
     del connection


### PR DESCRIPTION
Fixes issue https://github.com/twpayne/s3-parallel-put/issues/21 when
buckets are not in the US Standard region. Allows command line option
to specify a string region such as `—bucket-region=us-west-2`.