### PR TITLE
add CLI description plus default bucket_region (us-east-1)

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -318,6 +318,8 @@ def main(argv):
     group = OptionGroup(parser, 'S3 options')
     group.add_option('--bucket', metavar='BUCKET',
             help='set bucket')
+    group.add_option('--bucket_region', default='us-east-1',
+            help='set bucket region if not in us-east-1 (default new bucket region)')
     group.add_option('--host', default='s3.amazonaws.com',
             help='set AWS host name')
     group.add_option('--insecure', action='store_false', dest='secure',
@@ -378,6 +380,8 @@ def main(argv):
     if not options.bucket:
         logger.error('missing bucket')
         return 1
+    if not options.bucket_region:
+        options.bucket_region = 'us-east-1'
     connection = boto.s3.connect_to_region(options.bucket_region,
        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),


### PR DESCRIPTION
and default to `us-east-1` if not supplied. per
https://github.com/twpayne/s3-parallel-put/commit/fef435bed00b3050f34d7f
7a3faed11890688ebd#commitcomment-13084920

again with no tests and as a non-daily Python programmer, this is me just sorta whiteboarding fixes as PRs since I have no further reason to test this "fix" I've contributed.